### PR TITLE
update mongodb.driver to 2.19.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 <Project>
 
 	<PropertyGroup>
-		<Version>1.3.3</Version>
+		<Version>1.3.4</Version>
 		<LangVersion>preview</LangVersion>
 		<RepositoryUrl>https://github.com/EasilyNET/EasilyNET</RepositoryUrl>
 		<Nullable>enable</Nullable>

--- a/src/EasilyNET.IdentityServer.MongoStorage/EasilyNET.IdentityServer.MongoStorage.csproj
+++ b/src/EasilyNET.IdentityServer.MongoStorage/EasilyNET.IdentityServer.MongoStorage.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Duende.IdentityServer" Version="6.2.3" />
-        <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+        <PackageReference Include="Duende.IdentityServer" Version="6.3.0-preview.1.1" />
+        <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
     </ItemGroup>
 
 </Project>

--- a/src/EasilyNET.Mongo.ConsoleDebug/EasilyNET.Mongo.ConsoleDebug.csproj
+++ b/src/EasilyNET.Mongo.ConsoleDebug/EasilyNET.Mongo.ConsoleDebug.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver.Core" Version="2.19.0" />
+        <PackageReference Include="MongoDB.Driver.Core" Version="2.19.1" />
     </ItemGroup>
 
 </Project>

--- a/src/EasilyNET.Mongo.Extension/EasilyNET.Mongo.Extension.csproj
+++ b/src/EasilyNET.Mongo.Extension/EasilyNET.Mongo.Extension.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.2.23128.3" />
-        <PackageReference Include="MongoDB.Bson" Version="2.19.0" />
+        <PackageReference Include="MongoDB.Bson" Version="2.19.1" />
     </ItemGroup>
 
 </Project>

--- a/src/EasilyNET.Mongo.Extension/README.md
+++ b/src/EasilyNET.Mongo.Extension/README.md
@@ -1,6 +1,6 @@
 #### EasilyNET.Mongo.Extension
 
-EasilyNET.Mongo扩展,用于支持一些非默认类型的序列化方案.
+EasilyNET.Mongo扩展,用于支持一些非默认类型的序列化方案.就算是没有使用 EasilyNET.Mongo 也能使用这个库进行如下内容的扩展.
 
 ##### ChangeLogs
 

--- a/src/EasilyNET.Mongo.GridFS/EasilyNET.Mongo.GridFS.csproj
+++ b/src/EasilyNET.Mongo.GridFS/EasilyNET.Mongo.GridFS.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
         <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.2.23128.3" />
-        <PackageReference Include="MongoDB.Driver.GridFS" Version="2.19.0" />
+        <PackageReference Include="MongoDB.Driver.GridFS" Version="2.19.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EasilyNET.Mongo/EasilyNET.Mongo.csproj
+++ b/src/EasilyNET.Mongo/EasilyNET.Mongo.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0-preview.2.23128.3" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-preview.2.23128.3" />
-        <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# .NET Driver Version 2.19.1 Release Notes

This is a patch release that addresses some issues reported since 2.19.0 was released.

An online version of these release notes is available [here](https://github.com/mongodb/mongo-csharp-driver/blob/master/Release%20Notes/Release%20Notes%20v2.19.1.md).

The list of JIRA tickets resolved in this release is available at [CSHARP JIRA project](https://jira.mongodb.org/issues/?jql=project%20%3D%20CSHARP%20AND%20fixVersion%20%3D%202.19.1%20ORDER%20BY%20key%20ASC).

Documentation on the .NET driver can be found [here](https://www.mongodb.com/docs/drivers/csharp/v2.19/).

## Upgrading

There are no known backwards breaking changes in this release.