### PR TITLE
bug fix

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -37,6 +37,7 @@ exec { & dotnet pack .\src\EasilyNET.WebCore\EasilyNET.WebCore.csproj -c Release
 # Framework
 exec { & dotnet pack .\src\EasilyNET.AutoDependencyInjection\EasilyNET.AutoDependencyInjection.csproj -c Release -o $artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
 exec { & dotnet pack .\src\EasilyNET.RabbitBus\EasilyNET.RabbitBus.csproj -c Release -o $artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
+exec { & dotnet pack .\src\EasilyNET.RabbitBus.Core\EasilyNET.RabbitBus.Core.csproj -c Release -o $artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
 exec { & dotnet pack .\src\EasilyNET.Security\EasilyNET.Security.csproj -c Release -o $artifacts --include-symbols -p:SymbolPackageFormat=snupkg --no-build }
 
 # Mongo

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 <Project>
 
 	<PropertyGroup>
-		<Version>1.3.5</Version>
+		<Version>1.3.6</Version>
 		<LangVersion>preview</LangVersion>
 		<RepositoryUrl>https://github.com/EasilyNET/EasilyNET</RepositoryUrl>
 		<Nullable>enable</Nullable>

--- a/EasilyNET.sln
+++ b/EasilyNET.sln
@@ -50,6 +50,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasilyNET.Security", "src\EasilyNET.Security\EasilyNET.Security.csproj", "{81F28F9F-77CF-43C2-8732-8B03B54F185F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasilyNET.RabbitBus.Core", "src\EasilyNET.RabbitBus.Core\EasilyNET.RabbitBus.Core.csproj", "{D39C32BF-85C7-41FA-968A-88CE4AEB41B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -112,6 +114,10 @@ Global
 		{81F28F9F-77CF-43C2-8732-8B03B54F185F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81F28F9F-77CF-43C2-8732-8B03B54F185F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81F28F9F-77CF-43C2-8732-8B03B54F185F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D39C32BF-85C7-41FA-968A-88CE4AEB41B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D39C32BF-85C7-41FA-968A-88CE4AEB41B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D39C32BF-85C7-41FA-968A-88CE4AEB41B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D39C32BF-85C7-41FA-968A-88CE4AEB41B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -134,6 +140,7 @@ Global
 		{5ED53752-8FF1-4A77-AE25-676401CEE6F1} = {2CB52E13-C7D0-4C8C-BFAD-F1A115AD5373}
 		{FDE3D67B-FA75-4806-8839-8B080893579C} = {2CB52E13-C7D0-4C8C-BFAD-F1A115AD5373}
 		{81F28F9F-77CF-43C2-8732-8B03B54F185F} = {BD6D1E2B-691E-4E8B-9E8D-E7FD2EDDF1F8}
+		{D39C32BF-85C7-41FA-968A-88CE4AEB41B9} = {BD6D1E2B-691E-4E8B-9E8D-E7FD2EDDF1F8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {04F52789-9FF4-4AB9-9132-1789A00E7E4A}

--- a/Test/WebApi.Test.Unit/Controllers/RabbitBusController.cs
+++ b/Test/WebApi.Test.Unit/Controllers/RabbitBusController.cs
@@ -1,5 +1,5 @@
 using EasilyNET.Core.Language;
-using EasilyNET.RabbitBus.Abstractions;
+using EasilyNET.RabbitBus.Core;
 using Microsoft.AspNetCore.Mvc;
 using WebApi.Test.Unit.Events;
 

--- a/Test/WebApi.Test.Unit/EventHandlers/WeatherForecastHandler.cs
+++ b/Test/WebApi.Test.Unit/EventHandlers/WeatherForecastHandler.cs
@@ -1,5 +1,5 @@
 ﻿using EasilyNET.AutoDependencyInjection.Attributes;
-using EasilyNET.RabbitBus.Abstractions;
+using EasilyNET.RabbitBus.Core;
 using System.Text.Json;
 using WebApi.Test.Unit.Events;
 

--- a/Test/WebApi.Test.Unit/Events/WeatherForecastEvent.cs
+++ b/Test/WebApi.Test.Unit/Events/WeatherForecastEvent.cs
@@ -1,6 +1,6 @@
 using EasilyNET.RabbitBus;
-using EasilyNET.RabbitBus.Attributes;
-using EasilyNET.RabbitBus.Enums;
+using EasilyNET.RabbitBus.Core.Attributes;
+using EasilyNET.RabbitBus.Core.Enums;
 
 namespace WebApi.Test.Unit.Events;
 

--- a/src/EasilyNET.RabbitBus.Core/Attributes/RabbitAttribute.cs
+++ b/src/EasilyNET.RabbitBus.Core/Attributes/RabbitAttribute.cs
@@ -1,9 +1,9 @@
-﻿using EasilyNET.RabbitBus.Enums;
-using EasilyNET.RabbitBus.Extensions;
+﻿// ReSharper disable ClassNeverInstantiated.Global
 
-// ReSharper disable ClassNeverInstantiated.Global
+using EasilyNET.RabbitBus.Core.Enums;
+using EasilyNET.RabbitBus.Core.Extensions;
 
-namespace EasilyNET.RabbitBus.Attributes;
+namespace EasilyNET.RabbitBus.Core.Attributes;
 
 /// <summary>
 /// 应用交换机队列等参数

--- a/src/EasilyNET.RabbitBus.Core/Attributes/RabbitDictionaryAttribute.cs
+++ b/src/EasilyNET.RabbitBus.Core/Attributes/RabbitDictionaryAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace EasilyNET.RabbitBus.Attributes;
+﻿namespace EasilyNET.RabbitBus.Core.Attributes;
 
 /// <summary>
 /// Rabbit字典

--- a/src/EasilyNET.RabbitBus.Core/Attributes/RabbitExchangeArgAttribute.cs
+++ b/src/EasilyNET.RabbitBus.Core/Attributes/RabbitExchangeArgAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// ReSharper disable ClassNeverInstantiated.Global
 
-namespace EasilyNET.RabbitBus.Attributes;
+namespace EasilyNET.RabbitBus.Core.Attributes;
 
 /// <summary>
 /// RabbitMQ参数特性

--- a/src/EasilyNET.RabbitBus.Core/Attributes/RabbitHeaderAttribute.cs
+++ b/src/EasilyNET.RabbitBus.Core/Attributes/RabbitHeaderAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// ReSharper disable ClassNeverInstantiated.Global
 
-namespace EasilyNET.RabbitBus.Attributes;
+namespace EasilyNET.RabbitBus.Core.Attributes;
 
 /// <summary>
 /// 添加RabbitMQ,Headers参数特性

--- a/src/EasilyNET.RabbitBus.Core/Attributes/RabbitQueueArgAttribute.cs
+++ b/src/EasilyNET.RabbitBus.Core/Attributes/RabbitQueueArgAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace EasilyNET.RabbitBus.Attributes;
+﻿namespace EasilyNET.RabbitBus.Core.Attributes;
 
 /// <summary>
 /// 作用于队列的Arguments

--- a/src/EasilyNET.RabbitBus.Core/EasilyNET.RabbitBus.Core.csproj
+++ b/src/EasilyNET.RabbitBus.Core/EasilyNET.RabbitBus.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	  <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+	  <PackageProjectUrl>https://www.nuget.org/packages/EasilyNET.RabbitBus.Core</PackageProjectUrl>
+	  <Description>EventBus抽象</Description>
+  </PropertyGroup>
+
+</Project>

--- a/src/EasilyNET.RabbitBus.Core/Enums/EExchange.cs
+++ b/src/EasilyNET.RabbitBus.Core/Enums/EExchange.cs
@@ -2,7 +2,7 @@
 
 // ReSharper disable UnusedMember.Global
 
-namespace EasilyNET.RabbitBus.Enums;
+namespace EasilyNET.RabbitBus.Core.Enums;
 
 /// <summary>
 /// 交换机类型

--- a/src/EasilyNET.RabbitBus.Core/Extensions/EnumExtensions.cs
+++ b/src/EasilyNET.RabbitBus.Core/Extensions/EnumExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+
+namespace EasilyNET.RabbitBus.Core.Extensions;
+
+/// <summary>
+/// 扩展枚举
+/// </summary>
+internal static class EnumExtensions
+{
+    /// <summary>
+    /// 转成显示名字
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    internal static string? ToDescription(this Enum value)
+    {
+        var member = value.GetType().GetMember(value.ToString()).FirstOrDefault();
+        return member?.ToDescription();
+    }
+
+    /// <summary>
+    /// 获取描述或者显示名称
+    /// </summary>
+    /// <param name="member"></param>
+    /// <returns></returns>
+    private static string ToDescription(this MemberInfo member)
+    {
+        var desc = member.GetCustomAttribute<DescriptionAttribute>();
+        if (desc is not null) return desc.Description;
+        //显示名
+        var display = member.GetCustomAttribute<DisplayNameAttribute>();
+        return display is not null ? display.DisplayName : member.Name;
+    }
+}

--- a/src/EasilyNET.RabbitBus.Core/IIntegrationEvent.cs
+++ b/src/EasilyNET.RabbitBus.Core/IIntegrationEvent.cs
@@ -1,4 +1,4 @@
-﻿namespace EasilyNET.RabbitBus.Abstractions;
+﻿namespace EasilyNET.RabbitBus.Core;
 
 /// <summary>
 /// 自定义事件继承接口

--- a/src/EasilyNET.RabbitBus.Core/IIntegrationEventBus.cs
+++ b/src/EasilyNET.RabbitBus.Core/IIntegrationEventBus.cs
@@ -1,4 +1,4 @@
-﻿namespace EasilyNET.RabbitBus.Abstractions;
+﻿namespace EasilyNET.RabbitBus.Core;
 
 /// <summary>
 /// 发送事件接口定义

--- a/src/EasilyNET.RabbitBus.Core/IIntegrationEventHandler.cs
+++ b/src/EasilyNET.RabbitBus.Core/IIntegrationEventHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace EasilyNET.RabbitBus.Abstractions;
+﻿namespace EasilyNET.RabbitBus.Core;
 
 /// <summary>
 /// 集成事件处理器

--- a/src/EasilyNET.RabbitBus.Core/README.md
+++ b/src/EasilyNET.RabbitBus.Core/README.md
@@ -1,0 +1,3 @@
+#### EasilyNET.RabbitBus.Core
+
+将部分成员抽离出来,便于将EventMessage独立成库,减少引用.同时减少不同的项目重复声明事件消息

--- a/src/EasilyNET.RabbitBus/Abstraction/IPersistentConnection.cs
+++ b/src/EasilyNET.RabbitBus/Abstraction/IPersistentConnection.cs
@@ -1,6 +1,6 @@
 ﻿using RabbitMQ.Client;
 
-namespace EasilyNET.RabbitBus.Abstractions;
+namespace EasilyNET.RabbitBus.Abstraction;
 
 /// <summary>
 /// RabbitMQ链接

--- a/src/EasilyNET.RabbitBus/Abstraction/ISubscriptionsManager.cs
+++ b/src/EasilyNET.RabbitBus/Abstraction/ISubscriptionsManager.cs
@@ -1,4 +1,4 @@
-﻿namespace EasilyNET.RabbitBus.Abstractions;
+﻿namespace EasilyNET.RabbitBus.Abstraction;
 
 /// <summary>
 /// 订阅管理器接口

--- a/src/EasilyNET.RabbitBus/EasilyNET.RabbitBus.csproj
+++ b/src/EasilyNET.RabbitBus/EasilyNET.RabbitBus.csproj
@@ -14,4 +14,8 @@
         <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\EasilyNET.RabbitBus.Core\EasilyNET.RabbitBus.Core.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/EasilyNET.RabbitBus/Extensions/IntegrationEventExtension.cs
+++ b/src/EasilyNET.RabbitBus/Extensions/IntegrationEventExtension.cs
@@ -1,5 +1,5 @@
-﻿using EasilyNET.RabbitBus.Abstractions;
-using EasilyNET.RabbitBus.Attributes;
+﻿using EasilyNET.RabbitBus.Core;
+using EasilyNET.RabbitBus.Core.Attributes;
 using System.Reflection;
 
 namespace EasilyNET.RabbitBus.Extensions;

--- a/src/EasilyNET.RabbitBus/IntegrationEvent.cs
+++ b/src/EasilyNET.RabbitBus/IntegrationEvent.cs
@@ -1,4 +1,4 @@
-﻿using EasilyNET.RabbitBus.Abstractions;
+﻿using EasilyNET.RabbitBus.Core;
 using System.Text.Json.Serialization;
 
 namespace EasilyNET.RabbitBus;

--- a/src/EasilyNET.RabbitBus/IntegrationEventBus.cs
+++ b/src/EasilyNET.RabbitBus/IntegrationEventBus.cs
@@ -1,6 +1,7 @@
-﻿using EasilyNET.RabbitBus.Abstractions;
-using EasilyNET.RabbitBus.Attributes;
-using EasilyNET.RabbitBus.Enums;
+﻿using EasilyNET.RabbitBus.Abstraction;
+using EasilyNET.RabbitBus.Core;
+using EasilyNET.RabbitBus.Core.Attributes;
+using EasilyNET.RabbitBus.Core.Enums;
 using EasilyNET.RabbitBus.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -153,6 +154,10 @@ internal sealed class IntegrationEventBus : IIntegrationEventBus, IDisposable
                 using var consumerChannel = CreateConsumerChannel(rabbitAttr, eventType);
                 var eventName = _subsManager.GetEventKey(eventType);
                 DoInternalSubscription(eventName, rabbitAttr, consumerChannel);
+                using var scope = _serviceProvider.GetService<IServiceScopeFactory>()?.CreateScope();
+                // 检查消费者是否已经注册,若是未注册则不启动消费.
+                var handler = scope?.ServiceProvider.GetService(implementedType!);
+                if (handler is null) return;
                 _subsManager.AddSubscription(eventType, handlerType);
                 StartBasicConsume(eventType, rabbitAttr, consumerChannel);
             });

--- a/src/EasilyNET.RabbitBus/PersistentConnection.cs
+++ b/src/EasilyNET.RabbitBus/PersistentConnection.cs
@@ -1,4 +1,4 @@
-﻿using EasilyNET.RabbitBus.Abstractions;
+﻿using EasilyNET.RabbitBus.Abstraction;
 using Microsoft.Extensions.Logging;
 using Polly;
 using RabbitMQ.Client;

--- a/src/EasilyNET.RabbitBus/ServiceCollectionExtension.cs
+++ b/src/EasilyNET.RabbitBus/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
-﻿using EasilyNET.RabbitBus.Abstractions;
+﻿using EasilyNET.RabbitBus.Abstraction;
+using EasilyNET.RabbitBus.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;

--- a/src/EasilyNET.RabbitBus/SubscribeService.cs
+++ b/src/EasilyNET.RabbitBus/SubscribeService.cs
@@ -1,4 +1,4 @@
-﻿using EasilyNET.RabbitBus.Abstractions;
+﻿using EasilyNET.RabbitBus.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 

--- a/src/EasilyNET.RabbitBus/SubscriptionsManager.cs
+++ b/src/EasilyNET.RabbitBus/SubscriptionsManager.cs
@@ -1,4 +1,4 @@
-﻿using EasilyNET.RabbitBus.Abstractions;
+﻿using EasilyNET.RabbitBus.Abstraction;
 using System.Collections.Concurrent;
 
 namespace EasilyNET.RabbitBus;


### PR DESCRIPTION
- 修复消费者未启动的情况下,消息未被消费确认造成的问题,导致只有一个消费者能消费.
- 将RabbitBus部分成员抽离成单独的Core库,便于后期多个项目引用同一份消息实体声明.减少声明次数.
---
- Fix the problem that only one consumer can consume the message if the consumer is not started and the message is not consumed.
- Separate some RabbitBus members into a separate Core library, so that multiple projects can refer to the same message entity declaration later. Reduce the number of declarations.