### PR TITLE
fix-nationality

### DIFF
--- a/src/EasilyNET.Core/Enums/ENation.cs
+++ b/src/EasilyNET.Core/Enums/ENation.cs
@@ -343,7 +343,7 @@ public enum ENation
     /// <summary>
     /// Jino
     /// </summary>
-    [Description("")]
+    [Description("Jino")]
     基诺族 = 56,
 
     /// <summary>
@@ -351,6 +351,12 @@ public enum ENation
     /// </summary>
     [Description("Chuanqing")]
     穿青人 = 57,
+
+    /// <summary>
+    /// Undefined ethnicity population
+    /// </summary>
+    [Description("Undefined")]
+    未定族称人口 = 97,
 
     /// <summary>
     /// Foreign-born Chinese nationals


### PR DESCRIPTION
修复基诺族描述特性值为空的情况。
根据第七次全国人口普查民族代码表新增 未定族称人口97。